### PR TITLE
Add description field and bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ about:
   home: https://pypi.org/project/pytest-nunit
   dev_url: https://github.com/pytest-dev/pytest-nunit
   doc_source_url: https://github.com/pytest-dev/pytest-nunit
+  description: A pytest plugin for generating NUnit3 test result XML output
   summary: A pytest plugin for generating NUnit3 test result XML output
   license: MIT
   license_family: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 29cd259b847510d751c971af987a15dcbb843ec2d076dd03f31cac7a848bed90
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check


### PR DESCRIPTION
Missed adding the `description` metadata in the previous PR, which the AI team will be needing. Added that and bumped build number to trigger a rebuild.